### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,6 +4,8 @@
 # `https://help.github.com/actions/language-and-framework-guides/`
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Adam-Robson/webpackjs/security/code-scanning/1](https://github.com/Adam-Robson/webpackjs/security/code-scanning/1)

To fix the problem, we need to add an explicit `permissions` block to the workflow file. Since the workflow performs actions like checking out code but does not require permission to write to GitHub resources (except potentially reading the codebase), the minimal permission of `contents: read` is suitable. This should be set at the top (root) of the workflow (under `name:` and above `on:`), which will apply to all jobs unless overridden.

**Change needed:**  
- Edit `.github/workflows/node.js.yml`  
- Insert the following lines after `name: Node.js CI` (i.e., below line 6 and above line 8):

```yaml
permissions:
  contents: read
```

No additional methods, external libraries, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
